### PR TITLE
Fix: Handle missing links.json in Quote initialization when installing through pip

### DIFF
--- a/jufinance/quote.py
+++ b/jufinance/quote.py
@@ -2,6 +2,7 @@
 # - current price, company info, etc.
 
 from jufinance.scrapers import Investing, MoneyControl, Screener
+
 import datetime as dt
 
 
@@ -159,3 +160,8 @@ class Quote:
         """
         # print("Getting top news")
         return self.mc.top_news()
+
+if __name__ == "__main__":
+    quote = Quote("HDFC")
+    cur = quote.get_current_price()
+    print(cur)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
     long_description_content_type="text/markdown",
     url=GITHUB_URL,
     packages=find_packages(),
+    include_package_data=True,  # This ensures package data is included
+    package_data={
+        'jufinance': ['scrapers/links.json'],  # Add the path to links.json
+    },
     install_requires=[
         "beautifulsoup4",
         "bs4",


### PR DESCRIPTION
This PR fixes a `FileNotFoundError` that occurs when the `links.json` file is missing in the **jufinance/scrapers/ directory**. The error occurs during the initialization of the **Quote class** in `quote.py`. Fixed this error by including two parameter -  `include_package_data` and  `package_data` of `setuptools.setup`. This allows `links.json` file to be included while user installs jufinance through pip. 